### PR TITLE
Ensure whitespace only lines are ignored.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,20 +1,22 @@
 /*
 * Maze viewer
-* v2.0.0
+* v2.1.0
 * By Isaac Chen
-* 9/19/2022
+* With contributions from:
+*   - Calvin Higgins
 */
 
 // Parses a string into a Result<Maze, MazeErr> where:
 //   - Maze is a 2d array of ints with equal column widths
 //   - MazeErr is a string describing what went wrong
 function parse_maze(str) {
-    const maze = str.split("\n")
-                    .filter(s => s.trim()); // Ignore whitespace lines
+    const maze = str
+        .split("\n")
+        .filter(s => s.trim() === ""); // Ignore whitespace-only lines
 
     let maze_width = null;
     for(let i = 0; i < maze.length; i++) {
-	// Split the row by spaces
+        // Split the row by spaces
         maze[i] = maze[i].split(" ").filter(x => x !== "");
 
         // Ensure we have consistent widths

--- a/main.js
+++ b/main.js
@@ -9,14 +9,12 @@
 //   - Maze is a 2d array of ints with equal column widths
 //   - MazeErr is a string describing what went wrong
 function parse_maze(str) {
-    const maze = str.split("\n");
-    
-    // Strip trailing newline
-    if(maze[maze.length - 1].length === 0) maze.pop();
-    
+    const maze = str.split("\n")
+                    .filter(s => s.trim()); // Ignore whitespace lines
+
     let maze_width = null;
     for(let i = 0; i < maze.length; i++) {
-        // Split the row by spaces
+	// Split the row by spaces
         maze[i] = maze[i].split(" ").filter(x => x !== "");
 
         // Ensure we have consistent widths


### PR DESCRIPTION
This PR fixes #1. Whitespace only lines are filtered out when the maze is split into rows. This avoids a special case for the last row in the maze.